### PR TITLE
QLB Yearly + adam removal

### DIFF
--- a/sixMans/game.py
+++ b/sixMans/game.py
@@ -585,7 +585,7 @@ class Game:
                 "the `winning_team` parameter is either `Blue` or `Orange`. Both teams will need to verify the results.\n\nIf you wish to cancel "
                 "the game and allow players to queue again you can use the `{0}cg` command. Both teams will need to verify that they wish to "
                 "cancel the game.".format(self.prefix), inline=False)
-        help_message = "If you think the bot isn't working correctly or have suggestions to improve it, please contact adammast."
+        help_message = "If you think the bot isn't working correctly or have suggestions to improve it, please contact the RSC Development Committee."
         if helper_role:
             help_message = "If you need any help or have questions please contact someone with the {0} role. ".format(helper_role.mention) + help_message
         embed.add_field(name="Help", value=help_message, inline=False)
@@ -663,7 +663,7 @@ class Game:
             voted = "{} {}".format(self._get_pick_reaction(winning_vote), SELECTION_MODES[winning_vote])
             embed.add_field(name="Vote Complete!", value=voted, inline=False)
         
-        help_message = "If you think the bot isn't working correctly or have suggestions to improve it, please contact adammast."
+        help_message = "If you think the bot isn't working correctly or have suggestions to improve it, please contact the RSC Development Committee."
         if self.helper_role:
             help_message = "If you need any help or have questions please contact someone with the {0} role. ".format(self.helper_role.mention) + help_message
         embed.add_field(name="Help", value=help_message, inline=False)
@@ -734,7 +734,7 @@ class Game:
         embed.add_field(name="Orange Team", value=orange_players, inline=False)
         embed.add_field(name="Unplaced Players", value=unplaced_players, inline=False)
 
-        help_message = "If you think the bot isn't working correctly or have suggestions to improve it, please contact adammast."
+        help_message = "If you think the bot isn't working correctly or have suggestions to improve it, please contact the RSC Development Committee."
         if self.helper_role:
             help_message = "If you need any help or have questions please contact someone with the {0} role. ".format(self.helper_role.mention) + help_message
         embed.add_field(name="Help", value=help_message, inline=False)

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -778,7 +778,7 @@ class SixMans(commands.Cog):
 
     @commands.guild_only()
     @queueLeaderBoard.command(aliases=["yearly", "yr"])
-    async def month(self, ctx: Context, *, queue_name: str = None):
+    async def year(self, ctx: Context, *, queue_name: str = None):
         """Yearly leader board. All games from the last 365 days will count"""
         scores = await self._scores(ctx.guild)
 
@@ -887,6 +887,27 @@ class SixMans(commands.Cog):
         sorted_players = self._sort_player_dict(players)
         player = player if player else ctx.author
         await ctx.send(embed=self.embed_rank(player, sorted_players, queue_name, queue_max_size, "Monthly"))
+
+    @commands.guild_only()
+    @rank.command(aliases=["year", "yr"])
+    async def yearly(self, ctx: Context, player: discord.Member = None, *, queue_name: str = None):
+        """Yearly ranks. All games from the last 30 days will count"""
+        scores = await self._scores(ctx.guild)
+
+        queue = await self._get_queue_by_name(ctx.guild, queue_name) if queue_name else None
+        queue_id = queue.id if queue else None
+        year_ago = datetime.datetime.now() - datetime.timedelta(days=365)
+        players = self._filter_scores(ctx.guild, scores, year_ago, queue_id)[0]
+        queue_name = queue.name if queue else ctx.guild.name
+
+        if not players:
+            await ctx.send(":x: Player ranks not available for {0}".format(queue_name))
+            return
+
+        queue_max_size = queue.maxSize if queue else self.queueMaxSize[ctx.guild]
+        sorted_players = self._sort_player_dict(players)
+        player = player if player else ctx.author
+        await ctx.send(embed=self.embed_rank(player, sorted_players, queue_name, queue_max_size, "Yearly"))
 
     #endregion
 

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -717,6 +717,7 @@ class SixMans(commands.Cog):
 
         sorted_players = self._sort_player_dict(players)
         await ctx.send(embed=await self.embed_leaderboard(ctx, sorted_players, queue_name, games_played, "All-time"))
+		
 
     @commands.guild_only()
     @queueLeaderBoard.command(aliases=["daily"])
@@ -774,6 +775,25 @@ class SixMans(commands.Cog):
         queue_name = queue.name if queue else ctx.guild.name
         sorted_players = self._sort_player_dict(players)
         await ctx.send(embed=await self.embed_leaderboard(ctx, sorted_players, queue_name, games_played, "Monthly"))
+
+    @commands.guild_only()
+    @queueLeaderBoard.command(aliases=["yearly", "yr"])
+    async def month(self, ctx: Context, *, queue_name: str = None):
+        """Yearly leader board. All games from the last 365 days will count"""
+        scores = await self._scores(ctx.guild)
+
+        queue = await self._get_queue_by_name(ctx.guild, queue_name) if queue_name else None
+        queue_id = queue.id if queue else None
+        year_ago = datetime.datetime.now() - datetime.timedelta(days=365)
+        players, games_played = self._filter_scores(ctx.guild, scores, year_ago, queue_id)
+
+        if not players:
+            await ctx.send(":x: Queue leaderboard not available for {0}".format(queue_name))
+            return
+
+        queue_name = queue.name if queue else ctx.guild.name
+        sorted_players = self._sort_player_dict(players)
+        await ctx.send(embed=await self.embed_leaderboard(ctx, sorted_players, queue_name, games_played, "Yearly"))
 
     #endregion
 

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -891,7 +891,7 @@ class SixMans(commands.Cog):
     @commands.guild_only()
     @rank.command(aliases=["year", "yr"])
     async def yearly(self, ctx: Context, player: discord.Member = None, *, queue_name: str = None):
-        """Yearly ranks. All games from the last 30 days will count"""
+        """Yearly ranks. All games from the last 365 days will count"""
         scores = await self._scores(ctx.guild)
 
         queue = await self._get_queue_by_name(ctx.guild, queue_name) if queue_name else None


### PR DESCRIPTION
Adds the `.qlb yearly` option to display a queue leaderboard for the previous 365 days.

Also removes references to asking adam for help if anything is wrong and directs users to report bugs to the RSC Development Committee.