### PR TITLE
Patch: sixMans.py 'forceResult' error

### DIFF
--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -1585,6 +1585,8 @@ class SixMans(commands.Cog):
         _games_played = await self._games_played(guild)
         date_time = datetime.datetime.now().strftime("%d-%b-%Y (%H:%M:%S.%f)")
         for player in winning_players:
+            if not isinstance(player, discord.Member) and not isinstance(player, discord.User):
+                continue
             score = self._create_player_score(
                 six_mans_queue, game, player, 1, date_time
             )
@@ -1592,6 +1594,8 @@ class SixMans(commands.Cog):
             self._give_points(_players, score)
             _scores.insert(0, score)
         for player in losing_players:
+            if not isinstance(player, discord.Member) and not isinstance(player, discord.User):
+                continue
             score = self._create_player_score(
                 six_mans_queue, game, player, 0, date_time
             )


### PR DESCRIPTION
In this patch, I attempt to fix the following error:
```
[2024-01-15 00:23:05] [ERROR] red: Exception in command 'forceResult'
Traceback (most recent call last):
  File "/home/nickm/.virtualenvs/rscbot/lib/python3.11/site-packages/discord/ext/commands/core.py", line 235, in wrapped
    ret = await coro(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nickm/.local/share/Red-DiscordBot/data/RSC6Mans/cogs/CogManager/cogs/sixMans/sixMans.py", line 565, in forceResult
    await self._finish_game(ctx.guild, game, six_mans_queue, winning_team)
  File "/home/nickm/.local/share/Red-DiscordBot/data/RSC6Mans/cogs/CogManager/cogs/sixMans/sixMans.py", line 1588, in _finish_game
    score = self._create_player_score(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nickm/.local/share/Red-DiscordBot/data/RSC6Mans/cogs/CogManager/cogs/sixMans/sixMans.py", line 1707, in _create_player_score
    "Player": player.id,
              ^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'id'
```
The error seems to be a problem where the function tries to grab the member or user's id but when using discord.Member.id the object is a none type so it comes up with an error. This should fix it. Not pretty, but get the job done.